### PR TITLE
feat: Daily에서 Plan 추가/수정/삭제 가능하도록 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,15 @@ refactor: 타임 트래커 컴포넌트 분리
 
 타입: `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`, `perf`
 
+#### 설명 작성 원칙
+
+설명은 **코드 변경 내용이 아닌 기능/동작 관점**으로 서술한다.
+
+```
+좋은 예: fix: 22:00~00:00 selection 후 종료일이 다음날로 설정되지 않는 버그 수정
+나쁜 예: fix: minutesToDayjs에서 % HOURS_PER_DAY를 dayOffset 계산으로 변경
+```
+
 ### 커밋 전 체크리스트
 
 코드 변경 후 커밋하기 전에 반드시 아래 3가지를 확인한다:

--- a/frontend/src/app/(app)/daily/_api/func.ts
+++ b/frontend/src/app/(app)/daily/_api/func.ts
@@ -7,6 +7,13 @@ import {
   GetExecutionsQuery,
   UpdateExecutionBody,
 } from '@/types/execution'
+import {
+  CreatePlanBody,
+  GetPlansQuery,
+  PlanResponse,
+  PlansResponse,
+  UpdatePlanBody,
+} from '@/types/plan'
 import { CreateTaskBody, TaskResponse, UpdateTaskBody } from '@/types/task'
 
 export const getCategories = async () => {
@@ -51,5 +58,30 @@ export const updateExecution = async (id: number, data: UpdateExecutionBody) => 
 
 export const deleteExecution = async (id: number) => {
   const response = await api.delete<ExecutionResponse>(`/api/executions/${id}`)
+  return response.data?.data
+}
+
+export const getPlans = async ({ startTimestamp, endTimestamp }: GetPlansQuery) => {
+  const response = await api.get<PlansResponse>('/api/plans', {
+    params: {
+      startTimestamp,
+      endTimestamp,
+    },
+  })
+  return response.data?.data
+}
+
+export const createPlan = async (data: CreatePlanBody) => {
+  const response = await api.post<PlanResponse>('/api/plans', data)
+  return response.data?.data
+}
+
+export const updatePlan = async (id: number, data: UpdatePlanBody) => {
+  const response = await api.patch<PlanResponse>(`/api/plans/${id}`, data)
+  return response.data?.data
+}
+
+export const deletePlan = async (id: number) => {
+  const response = await api.delete<PlanResponse>(`/api/plans/${id}`)
   return response.data?.data
 }

--- a/frontend/src/app/(app)/daily/_components/time-table/plan-table/current-time-indicator.tsx
+++ b/frontend/src/app/(app)/daily/_components/time-table/plan-table/current-time-indicator.tsx
@@ -1,0 +1,23 @@
+import { BLOCK_PADDING } from '~/daily/_constants'
+
+interface CurrentTimeIndicatorProps {
+  minutePercent: number
+}
+
+/**
+ * 현재 시간 인디케이터
+ */
+export function CurrentTimeIndicator({ minutePercent }: CurrentTimeIndicatorProps) {
+  return (
+    <div
+      className="absolute z-10"
+      style={{
+        left: `${minutePercent}%`,
+        bottom: `${BLOCK_PADDING}px`,
+        top: `${BLOCK_PADDING}px`,
+      }}
+    >
+      <div className="h-full w-[3px] bg-primary rounded-full" />
+    </div>
+  )
+}

--- a/frontend/src/app/(app)/daily/_components/time-table/plan-table/index.tsx
+++ b/frontend/src/app/(app)/daily/_components/time-table/plan-table/index.tsx
@@ -1,21 +1,61 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
-import { useRef } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import dayjs from 'dayjs'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui'
 import { hours } from '@/constants'
 import { selectDayRange, useDateStore } from '@/store'
-import { useHoveredTime } from '~/daily/_hooks'
-import { getTimeBlocksForRow, preprocessTimeBlocks } from '~/daily/_utils'
-import { getPlans } from '~/weekly/_api/func'
+import type { Plan } from '@/types/plan'
+import { cn, minutesToDayjs } from '@/utils'
+import { deletePlan, getPlans } from '~/daily/_api/func'
+import { useCurrentTime, useHoveredTime, useSelection } from '~/daily/_hooks'
+import {
+  getCurrentTimePosition,
+  getSelectionForRow,
+  getTimeBlocksForRow,
+  preprocessTimeBlocks,
+} from '~/daily/_utils'
 
+import { CurrentTimeIndicator } from './current-time-indicator'
 import { GridBackground } from './grid-background'
 import { PlanBlock } from './plan-block'
+import { PlanFormDialog } from './plan-form-dialog'
+import { SelectionBlock } from './selection-block'
 import { TimeTooltip } from './time-tooltip'
 
 export function PlanTable() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const [addTargetPlan, setAddTargetPlan] = useState<Partial<Plan> | null>(null)
+  const [editTargetPlan, setEditTargetPlan] = useState<Plan | null>(null)
+  const [deleteTargetPlanId, setDeleteTargetPlanId] = useState<number | null>(null)
+  const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
+
+  const {
+    selection,
+    normalizedSelection,
+    displaySelection,
+    isDragging,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleClick,
+    clearSelection,
+  } = useSelection(containerRef)
+
+  const now = useCurrentTime()
+  const currentTimePosition = useMemo(() => getCurrentTimePosition(now), [now])
   const {
     hoveredTime,
     handleMouseMove,
@@ -24,7 +64,7 @@ export function PlanTable() {
     handleMouseMoveInTimeBlock,
   } = useHoveredTime(containerRef)
 
-  const { dayStartISO, dayEndISO } = useDateStore(useShallow(selectDayRange))
+  const { selectedDate, dayStartISO, dayEndISO } = useDateStore(useShallow(selectDayRange))
 
   const { data: processedPlans } = useQuery({
     queryKey: ['plans', dayStartISO, dayEndISO],
@@ -36,20 +76,80 @@ export function PlanTable() {
     select: (data) => preprocessTimeBlocks(data ?? []),
   })
 
+  const queryClient = useQueryClient()
+
+  const { mutate: deletePlanMutation } = useMutation({
+    mutationFn: (id: number) => deletePlan(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plans'] })
+      setDeleteTargetPlanId(null)
+    },
+  })
+
+  const handleSelectionClick = useCallback(
+    (selection: { start: number; end: number }): React.MouseEventHandler<HTMLDivElement> =>
+      (e) => {
+        e.stopPropagation()
+        setAddTargetPlan({
+          startTimestamp: minutesToDayjs(selection.start, selectedDate).toDate(),
+          endTimestamp: minutesToDayjs(selection.end, selectedDate).toDate(),
+        })
+      },
+    [selectedDate]
+  )
+
+  const handleEditPlanClick = useCallback(
+    (plan: Plan) => () => {
+      setEditTargetPlan(plan)
+    },
+    []
+  )
+
+  const handleDeletePlanClick = useCallback(
+    (id: number) => () => {
+      setDeleteTargetPlanId(id)
+    },
+    []
+  )
+
   return (
     <>
       <div
         ref={containerRef}
-        className="relative flex-1"
+        className={cn('relative flex-1', {
+          'cursor-col-resize select-none': isDragging,
+        })}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
         onMouseMove={handleMouseMove}
+        onPointerUp={handlePointerUp}
+        onClick={handleClick}
         onMouseLeave={handleMouseLeave}
       >
         {hours.map((hourIndex) => {
           const rowPlans = getTimeBlocksForRow(processedPlans ?? [], hourIndex)
+          const rowSelection = normalizedSelection
+            ? getSelectionForRow(normalizedSelection.start, normalizedSelection.end, hourIndex)
+            : null
+
+          const isToday = now && dayjs(selectedDate).isSame(dayjs(), 'day')
+          const showCurrentTime = isToday && currentTimePosition.hourIndex === hourIndex
 
           return (
             <div key={hourIndex} className="relative h-8 border-b border-zinc-200 last:border-b-0">
               <GridBackground />
+
+              {rowSelection && normalizedSelection && (
+                <SelectionBlock
+                  startPercent={rowSelection.startPercent}
+                  endPercent={rowSelection.endPercent}
+                  onClick={handleSelectionClick(normalizedSelection)}
+                />
+              )}
+
+              {showCurrentTime && (
+                <CurrentTimeIndicator minutePercent={currentTimePosition.minutePercent} />
+              )}
 
               {rowPlans.map(({ item: plan, offsetInRow, span, isStart }) => (
                 <PlanBlock
@@ -59,18 +159,65 @@ export function PlanTable() {
                   span={span}
                   isStart={isStart}
                   onMouseMove={handleMouseMoveInTimeBlock(plan)}
+                  onContextMenuChange={setIsContextMenuOpen}
+                  handleEditClick={handleEditPlanClick(plan)}
+                  handleDeleteClick={handleDeletePlanClick(plan.id)}
                 />
               ))}
             </div>
           )
         })}
       </div>
+      {/* 시간 Tooltip */}
+      {!isContextMenuOpen && selection && displaySelection && (
+        <TimeTooltip x={selection.x} top={selection.rowTop}>
+          {displaySelection}
+        </TimeTooltip>
+      )}
       {/* hover 시간 Tooltip */}
-      {hoveredTime && displayHoveredTime && (
+      {!isContextMenuOpen && !selection && hoveredTime && displayHoveredTime && (
         <TimeTooltip x={hoveredTime.x} top={hoveredTime.rowTop}>
           {displayHoveredTime}
         </TimeTooltip>
       )}
+      <PlanFormDialog
+        mode="add"
+        open={!!addTargetPlan}
+        plan={addTargetPlan}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAddTargetPlan(null)
+            clearSelection()
+          }
+        }}
+      />
+      <PlanFormDialog
+        mode="edit"
+        open={!!editTargetPlan}
+        plan={editTargetPlan}
+        onOpenChange={(open) => {
+          if (!open) setEditTargetPlan(null)
+        }}
+      />
+      <AlertDialog
+        open={deleteTargetPlanId !== null}
+        onOpenChange={() => setDeleteTargetPlanId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>정말 삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>이 작업은 되돌릴 수 없습니다.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteTargetPlanId && deletePlanMutation(deleteTargetPlanId)}
+            >
+              삭제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/frontend/src/app/(app)/daily/_components/time-table/plan-table/plan-block.tsx
+++ b/frontend/src/app/(app)/daily/_components/time-table/plan-table/plan-block.tsx
@@ -1,3 +1,12 @@
+import { PencilIcon, TrashIcon } from 'lucide-react'
+import { useCallback } from 'react'
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui'
 import type { Plan } from '@/types/plan'
 import { BLOCK_PADDING } from '~/daily/_constants'
 
@@ -7,28 +16,72 @@ interface PlanBlockProps {
   span: number
   isStart: boolean
   onMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void
+  onContextMenuChange?: (open: boolean) => void
+  handleEditClick: () => void
+  handleDeleteClick: () => void
 }
 
 /**
  * 타임블럭 (그리드 위에 overlay)
  */
-export function PlanBlock({ plan, offsetInRow, span, isStart, onMouseMove }: PlanBlockProps) {
+export function PlanBlock({
+  plan,
+  offsetInRow,
+  span,
+  isStart,
+  onMouseMove,
+  onContextMenuChange,
+  handleEditClick,
+  handleDeleteClick,
+}: PlanBlockProps) {
   const leftPercent = (offsetInRow / 60) * 100
   const widthPercent = (span / 60) * 100
 
+  // 좌클릭 시 클릭 위치에 컨텍스트 메뉴 표시
+  const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+    e.currentTarget.dispatchEvent(
+      new MouseEvent('contextmenu', {
+        bubbles: true,
+        clientX: e.clientX,
+        clientY: e.clientY,
+      })
+    )
+  }, [])
+
   return (
-    <div
-      className="absolute flex items-center overflow-hidden rounded text-sm text-white opacity-60"
-      style={{
-        bottom: `${BLOCK_PADDING}px`,
-        top: `${BLOCK_PADDING}px`,
-        left: `calc(${leftPercent}% + ${BLOCK_PADDING}px)`,
-        width: `calc(${widthPercent}% - ${BLOCK_PADDING * 2}px)`,
-        backgroundColor: plan.category?.color ?? '#a1a1aa',
-      }}
-      onMouseMove={onMouseMove}
-    >
-      {isStart && <span className="truncate px-2">{plan.title}</span>}
-    </div>
+    <ContextMenu onOpenChange={onContextMenuChange}>
+      <ContextMenuTrigger asChild>
+        <div
+          className="absolute flex items-center overflow-hidden rounded text-sm text-white cursor-pointer"
+          style={{
+            bottom: `${BLOCK_PADDING}px`,
+            top: `${BLOCK_PADDING}px`,
+            left: `calc(${leftPercent}% + ${BLOCK_PADDING}px)`,
+            width: `calc(${widthPercent}% - ${BLOCK_PADDING * 2}px)`,
+            backgroundColor: plan.category?.color ?? '#a1a1aa',
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={handleClick}
+          onMouseMove={onMouseMove}
+        >
+          {isStart && <span className="truncate px-2">{plan.title}</span>}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onPointerDown={(e) => e.stopPropagation()} onClick={handleEditClick}>
+          <PencilIcon />
+          <span>수정</span>
+        </ContextMenuItem>
+        <ContextMenuItem
+          variant="destructive"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={handleDeleteClick}
+        >
+          <TrashIcon />
+          <span>삭제</span>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/frontend/src/app/(app)/daily/_components/time-table/plan-table/plan-form-dialog.tsx
+++ b/frontend/src/app/(app)/daily/_components/time-table/plan-table/plan-form-dialog.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import dayjs from 'dayjs'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+
+import {
+  Button,
+  DateTimePicker,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui'
+import { useDateStore } from '@/store'
+import type { Plan, UpdatePlanBody } from '@/types/plan'
+import { createPlan, getCategories, updatePlan } from '~/daily/_api/func'
+
+type DialogMode = 'add' | 'edit'
+
+type PlanFormData = {
+  title: string
+  startTimestamp: Date
+  endTimestamp: Date
+  categoryId: number | null
+}
+
+interface PlanFormDialogProps {
+  mode: DialogMode
+  open: boolean
+  plan?: Partial<Plan> | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function PlanFormDialog({ mode, open, plan, onOpenChange }: PlanFormDialogProps) {
+  const selectedDate = useDateStore((state) => state.selectedDate)
+  const queryClient = useQueryClient()
+
+  const { data: categoriesByGroup } = useQuery({
+    queryKey: ['categories'],
+    queryFn: getCategories,
+    select: (data) => {
+      if (!data) return undefined
+      return Map.groupBy(data, (category) => category.categoryGroup?.name ?? '미분류')
+    },
+  })
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid },
+    setValue,
+    watch,
+    reset,
+  } = useForm<PlanFormData>({
+    mode: 'onChange',
+  })
+
+  const { startTimestamp, endTimestamp, categoryId } = watch()
+
+  useEffect(() => {
+    if (!open) return
+    reset({
+      title: '',
+      startTimestamp: selectedDate,
+      endTimestamp: selectedDate,
+      categoryId: null,
+      ...(plan ?? {}),
+    })
+  }, [open, plan, reset, selectedDate])
+
+  // 시작 시간 변경 핸들러
+  const handleStartChange = (date: Date) => {
+    setValue('startTimestamp', date, { shouldDirty: true })
+  }
+
+  // 종료 시간 변경 핸들러
+  const handleEndChange = (date: Date) => {
+    setValue('endTimestamp', date, { shouldDirty: true })
+  }
+
+  const { mutate: createPlanMutation, isPending: isCreating } = useMutation({
+    mutationFn: createPlan,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plans'] })
+      onOpenChange(false)
+    },
+  })
+
+  const { mutate: updatePlanMutation, isPending: isUpdating } = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: UpdatePlanBody }) => updatePlan(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plans'] })
+      onOpenChange(false)
+    },
+  })
+
+  const isPending = isCreating || isUpdating
+
+  const onSubmit = (data: PlanFormData) => {
+    const planData = {
+      title: data.title.trim(),
+      startTimestamp: dayjs(data.startTimestamp).second(0).millisecond(0).toISOString(),
+      endTimestamp: dayjs(data.endTimestamp).second(0).millisecond(0).toISOString(),
+      categoryId: data.categoryId ?? null,
+    }
+
+    if (mode === 'edit' && plan?.id) {
+      updatePlanMutation({ id: plan.id, data: planData })
+    } else {
+      createPlanMutation(planData)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{mode === 'edit' ? '계획 블럭 수정' : '계획 블럭 추가'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* 계획 블럭 제목 */}
+          <div className="space-y-2">
+            <label htmlFor="title" className="text-sm font-medium">
+              계획 블럭 제목
+            </label>
+            <Input
+              id="title"
+              {...register('title', { required: true, validate: (v) => !!v.trim() })}
+              placeholder="무엇을 계획했는지 입력하세요."
+            />
+          </div>
+
+          <DateTimePicker
+            startTimestamp={startTimestamp}
+            endTimestamp={endTimestamp}
+            isAllDay={false}
+            onStartTimestampChange={handleStartChange}
+            onEndTimestampChange={handleEndChange}
+          />
+
+          {/* 카테고리 선택 */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium">카테고리</label>
+            <Select
+              value={String(categoryId ?? '')}
+              onValueChange={(v) => setValue('categoryId', v ? Number(v) : null)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="카테고리 없음" />
+              </SelectTrigger>
+              <SelectContent>
+                {Array.from(categoriesByGroup?.entries() ?? []).map(([groupName, categories]) => (
+                  <SelectGroup key={groupName}>
+                    <SelectLabel>{groupName}</SelectLabel>
+                    {categories.map((category) => (
+                      <SelectItem key={category.id} value={String(category.id)}>
+                        <span
+                          className="size-2.5 rounded-full inline-block mr-1.5"
+                          style={{ backgroundColor: category.color }}
+                        />
+                        {category.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={isPending || !isValid}>
+              {isPending
+                ? mode === 'edit'
+                  ? '수정 중...'
+                  : '추가 중...'
+                : mode === 'edit'
+                  ? '수정'
+                  : '추가'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(app)/daily/_components/time-table/plan-table/selection-block.tsx
+++ b/frontend/src/app/(app)/daily/_components/time-table/plan-table/selection-block.tsx
@@ -1,0 +1,31 @@
+import { BLOCK_PADDING } from '~/daily/_constants'
+
+interface SelectionBlockProps {
+  startPercent: number
+  endPercent: number
+  onClick: React.MouseEventHandler<HTMLDivElement>
+}
+
+/**
+ * Selection 영역
+ */
+export function SelectionBlock({ startPercent, endPercent, onClick }: SelectionBlockProps) {
+  // 부모의 mousedown이 새 selection을 시작하는 것을 막기 위해 stopPropagation
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+  }
+
+  return (
+    <div
+      className="bg-primary/30 absolute rounded cursor-pointer"
+      style={{
+        top: `${BLOCK_PADDING}px`,
+        bottom: `${BLOCK_PADDING}px`,
+        left: `calc(${startPercent}% + ${BLOCK_PADDING}px)`,
+        width: `calc(${endPercent - startPercent}% - ${BLOCK_PADDING * 2}px)`,
+      }}
+      onPointerDown={handlePointerDown}
+      onClick={onClick}
+    />
+  )
+}

--- a/frontend/src/app/(app)/daily/_hooks/use-hovered-time.tsx
+++ b/frontend/src/app/(app)/daily/_hooks/use-hovered-time.tsx
@@ -73,7 +73,7 @@ export function useHoveredTime(containerRef: React.RefObject<HTMLDivElement | nu
 
   const displayHoveredTime = useMemo(() => {
     if (!hoveredTime) return null
-    if (hoveredTime.end) {
+    if (hoveredTime.end !== undefined) {
       return `${minutesToDayjs(hoveredTime.start, selectedDate).format('HH:mm')} - ${minutesToDayjs(hoveredTime.end, selectedDate).format('HH:mm')}`
     }
     return minutesToDayjs(hoveredTime.start, selectedDate).format('HH:mm')

--- a/frontend/src/app/(app)/daily/_utils/index.test.ts
+++ b/frontend/src/app/(app)/daily/_utils/index.test.ts
@@ -71,6 +71,30 @@ describe('preprocessTimeBlocks', () => {
     expect(result[0].startIndex).toBe(30)
     expect(result[0].endIndex).toBe(31)
   })
+
+  it('01:00~04:00 블럭 (자정 넘긴 종료) → startIndex=1260, endIndex=1440', () => {
+    const blocks = [
+      {
+        startTimestamp: new Date(2024, 0, 2, 1, 0, 0),
+        endTimestamp: new Date(2024, 0, 2, 4, 0, 0),
+      },
+    ]
+    const result = preprocessTimeBlocks(blocks)
+    expect(result[0].startIndex).toBe(1260)
+    expect(result[0].endIndex).toBe(1440)
+  })
+
+  it('03:30~04:00 블럭 (자정 넘긴 종료) → startIndex=1410, endIndex=1440', () => {
+    const blocks = [
+      {
+        startTimestamp: new Date(2024, 0, 2, 3, 30, 0),
+        endTimestamp: new Date(2024, 0, 2, 4, 0, 0),
+      },
+    ]
+    const result = preprocessTimeBlocks(blocks)
+    expect(result[0].startIndex).toBe(1410)
+    expect(result[0].endIndex).toBe(1440)
+  })
 })
 
 // hourIndex=1 기준: minutesStart=60, minutesEnd=120

--- a/frontend/src/app/(app)/daily/_utils/index.ts
+++ b/frontend/src/app/(app)/daily/_utils/index.ts
@@ -25,11 +25,15 @@ export function preprocessTimeBlocks<T extends TimeBlock>(blocks: T[]): Processe
     const startIndex = dateToMinutes(item.startTimestamp)
     const endIndex = dateToMinutes(item.endTimestamp)
 
+    // endIndex가 startIndex보다 작으면 자정(04:00)을 넘긴 것 → 하루치 분 추가
+    const correctedEndIndex =
+      endIndex < startIndex ? endIndex + HOURS_PER_DAY * MINUTES_PER_HOUR : endIndex
+
     return {
       item,
       startIndex,
       // 최소 1블럭 보장 (시작과 끝이 같은 블럭일 경우)
-      endIndex: endIndex <= startIndex ? startIndex + 1 : endIndex,
+      endIndex: correctedEndIndex <= startIndex ? startIndex + 1 : correctedEndIndex,
     }
   })
 }

--- a/frontend/src/app/(app)/habits/_components/habit-list/habit-card.tsx
+++ b/frontend/src/app/(app)/habits/_components/habit-list/habit-card.tsx
@@ -173,8 +173,9 @@ export const HabitCard: React.FC<HabitCardProps> = ({ habit }) => {
                   <div
                     key={cell.date}
                     className={cn(
-                      'flex aspect-square w-full items-center justify-center rounded text-xs font-medium opacity-50 bg-muted text-muted-foreground',
+                      'flex aspect-square w-full items-center justify-center rounded text-xs font-medium bg-muted text-muted-foreground',
                       {
+                        'opacity-50': dayjs().isBefore(cell.date),
                         'bg-green-100 text-green-700': log?.completedLevel === 1,
                         'bg-yellow-100 text-yellow-700': log?.completedLevel === 2,
                         'bg-red-100 text-red-700': log?.completedLevel === 3,

--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -38,7 +38,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui'
-import { useIsMobile } from '@/hooks'
+import { useAutoDateAdvance, useIsMobile } from '@/hooks'
 import { useDateStore } from '@/store'
 
 type MenuItem = { href: string; label: string; icon: React.ElementType }
@@ -75,6 +75,7 @@ const SIDEBAR_MENUS: MenuGroup[] = [
 ]
 
 export function AppSidebar() {
+  useAutoDateAdvance()
   const isMobile = useIsMobile()
   const pathname = usePathname()
   const selectedDate = useDateStore((state) => state.selectedDate)

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from './use-auto-date-advance'
 export * from './use-handle-task-toggle'
 export * from './use-mobile'

--- a/frontend/src/hooks/use-auto-date-advance.ts
+++ b/frontend/src/hooks/use-auto-date-advance.ts
@@ -1,0 +1,28 @@
+import dayjs from 'dayjs'
+import { useEffect } from 'react'
+
+import { START_HOUR } from '@/constants'
+import { useDateStore } from '@/store'
+
+// START_HOUR 기준 현재 플래너 날짜 반환
+// 04:00 이전이면 전날, 이후면 오늘
+const getCurrentPlannerDate = (): dayjs.Dayjs => {
+  const now = dayjs()
+  return now.hour() < START_HOUR ? now.subtract(1, 'day').startOf('day') : now.startOf('day')
+}
+
+export function useAutoDateAdvance() {
+  const selectedDate = useDateStore((state) => state.selectedDate)
+  const setSelectedDate = useDateStore((state) => state.setSelectedDate)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const today = getCurrentPlannerDate()
+      const yesterday = today.subtract(1, 'day')
+      if (dayjs(selectedDate).isSame(yesterday, 'day')) {
+        setSelectedDate(today.toDate())
+      }
+    }, 60000)
+    return () => clearInterval(interval)
+  }, [selectedDate, setSelectedDate])
+}

--- a/frontend/src/hooks/use-auto-date-advance.ts
+++ b/frontend/src/hooks/use-auto-date-advance.ts
@@ -1,15 +1,8 @@
 import dayjs from 'dayjs'
 import { useEffect } from 'react'
 
-import { START_HOUR } from '@/constants'
 import { useDateStore } from '@/store'
-
-// START_HOUR 기준 현재 플래너 날짜 반환
-// 04:00 이전이면 전날, 이후면 오늘
-const getCurrentPlannerDate = (): dayjs.Dayjs => {
-  const now = dayjs()
-  return now.hour() < START_HOUR ? now.subtract(1, 'day').startOf('day') : now.startOf('day')
-}
+import { getCurrentPlannerDate } from '@/utils'
 
 export function useAutoDateAdvance() {
   const selectedDate = useDateStore((state) => state.selectedDate)
@@ -17,7 +10,7 @@ export function useAutoDateAdvance() {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const today = getCurrentPlannerDate()
+      const today = dayjs(getCurrentPlannerDate())
       const yesterday = today.subtract(1, 'day')
       if (dayjs(selectedDate).isSame(yesterday, 'day')) {
         setSelectedDate(today.toDate())

--- a/frontend/src/store/use-date-store.ts
+++ b/frontend/src/store/use-date-store.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import { create } from 'zustand'
 
 import { START_HOUR } from '@/constants'
+import { getCurrentPlannerDate } from '@/utils'
 
 interface DateStore {
   // 선택된 날짜 (기본값: 오늘)
@@ -11,7 +12,7 @@ interface DateStore {
 }
 
 export const useDateStore = create<DateStore>((set) => ({
-  selectedDate: new Date(),
+  selectedDate: getCurrentPlannerDate(),
   setSelectedDate: (date) => set({ selectedDate: date }),
 }))
 

--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -1,8 +1,40 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { dateToMinutes, minutesToDayjs, toHourIndex, toMinuteInHour } from '.'
+import {
+  dateToMinutes,
+  getCurrentPlannerDate,
+  minutesToDayjs,
+  toHourIndex,
+  toMinuteInHour,
+} from '.'
 
 // START_HOUR = 4 기준
+describe('getCurrentPlannerDate', () => {
+  it('04:00 이전 (01:00) → 전날 날짜 반환', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 0, 2, 1, 0, 0)) // 2024-01-02 01:00
+    const result = getCurrentPlannerDate()
+    expect(result.getDate()).toBe(1) // 전날 (2024-01-01)
+    vi.useRealTimers()
+  })
+
+  it('04:00 이후 (10:00) → 오늘 날짜 반환', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 0, 2, 10, 0, 0)) // 2024-01-02 10:00
+    const result = getCurrentPlannerDate()
+    expect(result.getDate()).toBe(2) // 오늘 (2024-01-02)
+    vi.useRealTimers()
+  })
+
+  it('정확히 04:00 → 오늘 날짜 반환', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 0, 2, 4, 0, 0)) // 2024-01-02 04:00
+    const result = getCurrentPlannerDate()
+    expect(result.getDate()).toBe(2) // 오늘 (2024-01-02)
+    vi.useRealTimers()
+  })
+})
+
 describe('dateToMinutes', () => {
   it('04:00은 0분을 반환한다', () => {
     expect(dateToMinutes(new Date(2024, 0, 1, 4, 0, 0))).toBe(0)

--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { dateToMinutes, toHourIndex, toMinuteInHour } from '.'
+import { dateToMinutes, minutesToDayjs, toHourIndex, toMinuteInHour } from '.'
 
 // START_HOUR = 4 기준
 describe('dateToMinutes', () => {
@@ -26,5 +26,36 @@ describe('toHourIndex', () => {
 describe('toMinuteInHour', () => {
   it('90분은 시간 내 30분을 반환한다', () => {
     expect(toMinuteInHour(90)).toBe(30)
+  })
+})
+
+// START_HOUR=4, HOURS_PER_DAY=24, MINUTES_PER_HOUR=60 기준
+describe('minutesToDayjs', () => {
+  it('minutes=0 → 당일 04:00', () => {
+    const result = minutesToDayjs(0, new Date(2024, 0, 1))
+    expect(result.hour()).toBe(4)
+    expect(result.minute()).toBe(0)
+    expect(result.date()).toBe(1)
+  })
+
+  it('minutes=1080 → 당일 22:00', () => {
+    const result = minutesToDayjs(1080, new Date(2024, 0, 1))
+    expect(result.hour()).toBe(22)
+    expect(result.minute()).toBe(0)
+    expect(result.date()).toBe(1)
+  })
+
+  it('minutes=1200 → 다음날 00:00', () => {
+    const result = minutesToDayjs(1200, new Date(2024, 0, 1))
+    expect(result.hour()).toBe(0)
+    expect(result.minute()).toBe(0)
+    expect(result.date()).toBe(2)
+  })
+
+  it('minutes=1380 → 다음날 03:00', () => {
+    const result = minutesToDayjs(1380, new Date(2024, 0, 1))
+    expect(result.hour()).toBe(3)
+    expect(result.minute()).toBe(0)
+    expect(result.date()).toBe(2)
   })
 })

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -30,3 +30,10 @@ export const minutesToDayjs = (minutes: Minutes, baseDate: Date): dayjs.Dayjs =>
   const hour = totalHours % HOURS_PER_DAY
   return dayjs(baseDate).add(dayOffset, 'day').hour(hour).minute(toMinuteInHour(minutes))
 }
+
+// START_HOUR 기준 현재 플래너 날짜 반환 (04:00 이전이면 전날)
+export const getCurrentPlannerDate = (): Date => {
+  const now = dayjs()
+  const d = now.hour() < START_HOUR ? now.subtract(1, 'day') : now
+  return d.startOf('day').toDate()
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -25,6 +25,8 @@ export const toMinuteInHour = (minutes: Minutes): number => minutes % MINUTES_PE
 
 // 분 → dayjs 객체 (포맷팅용)
 export const minutesToDayjs = (minutes: Minutes, baseDate: Date): dayjs.Dayjs => {
-  const hour = (START_HOUR + toHourIndex(minutes)) % HOURS_PER_DAY
-  return dayjs(baseDate).hour(hour).minute(toMinuteInHour(minutes))
+  const totalHours = START_HOUR + toHourIndex(minutes)
+  const dayOffset = Math.floor(totalHours / HOURS_PER_DAY)
+  const hour = totalHours % HOURS_PER_DAY
+  return dayjs(baseDate).add(dayOffset, 'day').hour(hour).minute(toMinuteInHour(minutes))
 }


### PR DESCRIPTION
closes #37
closes #39
closes #40

## 개요

Daily 탭의 PlanTable에서 Plan 블럭을 추가, 수정, 삭제할 수 있도록 구현

## 변경 사항

### 1. Plan CRUD API 및 폼 다이얼로그

**변경 내용**

- (추가) `getPlans`, `createPlan`, `updatePlan`, `deletePlan` API 함수
- (추가) Plan 추가/수정 폼 다이얼로그 `PlanFormDialog` 컴포넌트

**변경 파일**

| 파일 | 설명 |
| ---- | ---- |
| `frontend/src/app/(app)/daily/_api/func.ts` | Plan CRUD API 함수 추가 |
| `frontend/src/app/(app)/daily/_components/time-table/plan-table/plan-form-dialog.tsx` | Plan 추가/수정 폼 다이얼로그 |

### 2. PlanTable 인터랙션 기능 구현

**변경 내용**

- (추가) Plan 블럭 클릭 시 수정/삭제 컨텍스트 메뉴 표시
- (추가) 빈 영역 드래그로 시간 범위 선택 후 Plan 추가 다이얼로그 열기
- (추가) 현재 시간 인디케이터 표시 (오늘 날짜일 때만)
- (추가) 드래그 선택 영역 시각화 `SelectionBlock`, 현재 시간 `CurrentTimeIndicator` 컴포넌트

**변경 파일**

| 파일 | 설명 |
| ---- | ---- |
| `frontend/src/app/(app)/daily/_components/time-table/plan-table/index.tsx` | CRUD/선택/현재 시간 기능 통합 |
| `frontend/src/app/(app)/daily/_components/time-table/plan-table/plan-block.tsx` | 컨텍스트 메뉴 (수정/삭제) 추가 |
| `frontend/src/app/(app)/daily/_components/time-table/plan-table/current-time-indicator.tsx` | 현재 시간 인디케이터 컴포넌트 |
| `frontend/src/app/(app)/daily/_components/time-table/plan-table/selection-block.tsx` | 드래그 선택 영역 블럭 컴포넌트 |

### 3. 자정 경계 시간 버그 수정

**변경 내용**

- (수정) 22:00~00:00 selection 후 생성 모달의 종료일이 다음날로 설정되지 않는 버그
- (수정) 01:00~04:00 plan 블럭이 1분으로 표시되는 버그
- (수정) 04:00 종료 plan 블럭 hover 시 종료 시간이 표시되지 않는 버그

**변경 파일**

| 파일 | 설명 |
| ---- | ---- |
| `frontend/src/utils/index.ts` | `minutesToDayjs` 날짜 롤오버 처리 추가 |
| `frontend/src/app/(app)/daily/_utils/index.ts` | `preprocessTimeBlocks` 04:00 종료 보정 |
| `frontend/src/app/(app)/daily/_hooks/use-hovered-time.tsx` | 0분 falsy 버그 수정 |

### 4. selectedDate 초기값 버그 수정

**변경 내용**

- (추가) `getCurrentPlannerDate` 유틸 함수 추출 (START_HOUR 기준 현재 플래너 날짜 반환)
- (수정) 자정~04:00 사이 앱 진입 시 selectedDate가 전날로 초기화되지 않는 버그

**변경 파일**

| 파일 | 설명 |
| ---- | ---- |
| `frontend/src/utils/index.ts` | `getCurrentPlannerDate` 유틸 추가 |
| `frontend/src/store/use-date-store.ts` | selectedDate 초기값을 `getCurrentPlannerDate()`로 변경 |
| `frontend/src/hooks/use-auto-date-advance.ts` | 내부 함수 제거 후 유틸 import |

## 체크리스트

- [x] `npm run test` 통과
- [x] `npm run lint` 통과
- [x] `npm run build` 통과

## 스크린샷

<!-- UI 변경이 있는 경우 첨부 -->